### PR TITLE
Only use mouse event click

### DIFF
--- a/extension/shared.js
+++ b/extension/shared.js
@@ -28,14 +28,6 @@ function reconnect(audioController, connection, isConnected) {
 }
 
 function simulateClick(element) {
-    var mousedown = document.createEvent('MouseEvents');
-    mousedown.initMouseEvent('mousedown', true, false,  document, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-    element.dispatchEvent(mousedown);
-
-    var mouseup = document.createEvent('MouseEvents');
-    mouseup.initMouseEvent('mouseup', true, false,  document, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-    element.dispatchEvent(mouseup);
-
     var click = document.createEvent('MouseEvents');
     click.initMouseEvent('click', true, false,  document, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
     element.dispatchEvent(click);


### PR DESCRIPTION
Hey,

Finally got around to addressing your comment over at: https://github.com/borismus/keysocket/pull/31#commitcomment-4556456

Sorry about the delay have been tied down with college work.

I have removed the click down click up code. Not sure why it was there in the first place. I based the simulateClick function of pre-existing code within the extension.

Testing with just using the click mouse event seems to work just fine.
