### PR TITLE
Ignore events for 250ms when received in extension

### DIFF
--- a/extension/shared.js
+++ b/extension/shared.js
@@ -17,10 +17,16 @@ function connect(audioController, connection, isConnected) {
     };
 
     window[connection].onmessage = function(e) {
-        console.log("keysocket: Got Key:", e.data);
-        var key = e.data;
-        audioController(key);
+      // if the message has been received within the last 250ms, ignore it.
+      if( window[connection].msgReceived ) { return; }
+      window[connection].msgReceived = setTimeout(function() {
+          window[connection].msgReceived = null;
+      },250);
+      console.log("keysocket: Got Key:", e.data);
+      var key = e.data;
+      audioController(key);
     };
+    
     window[connection].onclose = function(e) {
       console.log('keysocket: WS close', e);
       window[isConnected] = false;


### PR DESCRIPTION
This ignores all events for 250ms after one is received. This stops the
event from being handled more than once for one keypress.
