### PR TITLE
Fixes for YouTube when using the HTML5 <video>-player

### DIFF
--- a/extension/keysocket-youtube.js
+++ b/extension/keysocket-youtube.js
@@ -1,16 +1,29 @@
 function onKeyPress(key) {
     if(key === NEXT) {
-        var nextButton = document.getElementsByClassName('yt-uix-button-icon-playlist-bar-next')[0];
+        var nextButton = document.querySelector('.yt-uix-button-icon-playlist-bar-next,.yt-uix-button-icon-watch-appbar-play-next'); 
         simulateClick(nextButton);
     } else if(key === PLAY) {
-        var video = document.getElementById('movie_player');
-        if(video.getPlayerState() === 1) {
-            video.pauseVideo();
+        var video = document.querySelector('#movie_player');
+        
+        // The extension has no access to this function when using the HTML-5 <video>-player
+        // but we can still access the controls on the <video>-element itself
+        if(!video.getPlayerState) {
+            video = document.querySelector('#movie_player video'); // HTML-5 <video>-player
+        
+            if(video.paused) {
+                video.play();
+            } else {
+                video.pause();
+            }
         } else {
-            video.playVideo();
+            if(video.getPlayerState() === 2) {
+                video.playVideo();
+            } else {
+                video.pauseVideo();
+            }
         }
     } else if(key === PREV) {
-        var backButton = document.getElementsByClassName('yt-uix-button-icon-playlist-bar-prev')[0];
+        var backButton = document.querySelector('.yt-uix-button-icon-playlist-bar-prev,.yt-uix-button-icon-watch-appbar-play-prev');
         simulateClick(backButton);
     }
 }


### PR DESCRIPTION
1. The play/pause key didn't work when using the HTML-5 <video>-player. It now acts on the `<video>`-element directly. 
2. The next/previous-buttons in the 'appbar' (`.yt-uix-button-icon-watch-appbar-play-next`) are now found as well.
