### PR TITLE
http & https support for songza

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -124,7 +124,7 @@
       "js": ["shared.js","keysocket-dsaudio5.js"]
     },
     {
-      "matches": ["http://songza.com/*"],
+      "matches": ["*://songza.com/*"],
       "js": ["shared.js","keysocket-songza.js"]
     },
     {


### PR DESCRIPTION
I've modified manifest.json so that keyboard functionality works on both http and https.
  "matches": ["_://songza.com/_"],
      "js": ["shared.js","keysocket-songza.js"]
