### PR TITLE
Fix issues with Jamstash

### DIFF
--- a/extension/keysocket-jamstash.js
+++ b/extension/keysocket-jamstash.js
@@ -6,12 +6,10 @@ function onKeyPress(key) {
         var nextButton = document.getElementById('NextTrack');
         simulateClick(nextButton);
     } else if(key === PLAY) {
-        var isPlaying = document.getElementById('PlayTrack').style.display === 'none';
-        var playPauseButton = null;
+        var playPauseButton = document.getElementsByClassName('PlayTrack')[0];
+        var isPlaying = playPauseButton.style.display === 'none';
         if(isPlaying) {
-          playPauseButton = document.getElementById('PauseTrack');
-        } else {
-          playPauseButton = document.getElementById('PlayTrack');
+          playPauseButton = document.getElementsByClassName('PauseTrack')[0];
         }
         simulateClick(playPauseButton);
     }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -108,7 +108,7 @@
       "js": ["shared.js","keysocket-deezer.js"]
     },
     {
-      "matches": ["*://jamstash.com/*"],
+      "matches": ["*://jamstash.com/*", "*://*.jamstash.com/*"],
       "js": ["shared.js","keysocket-jamstash.js"]
     },
     {


### PR DESCRIPTION
Based on issues in tsquillario/Jamstash#189, tsquillario/Jamstash#194 and others

Add matching for the beta version of jamstash at beta.jamstash.com. As a result it will also work if accessed from www.jamstash.com.

Updates play/pause selection to work now that jamstash uses classes rather than ids to identify the play and pause buttons.

Working for me on Win8.1 with Chrome 39.0.2171.99 m and on OS X 10.10.1 with Chrome 41.0.2272.3 dev