### PR TITLE
Add support for regional Yandex.Music domains

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -88,7 +88,7 @@
       "js": ["shared.js","keysocket-slacker.js"]
     },
     {
-      "matches": ["*://music.yandex.ru/*"],
+      "matches": ["*://music.yandex.ru/*", "*://music.yandex.by/*", "*://music.yandex.ua/*", "*://music.yandex.kz/*", "*://music.yandex.tr/*"],
       "js": ["shared.js","keysocket-yandex-music.js"]
     },
     {


### PR DESCRIPTION
Yandex music player redirects users to local domain in some countries by IP (.by for Belarus, .ua for Ukraine, .kz for Kazakstan, .tr for Turkey). This patch adds additional domains to manifest `matches` block.