### PR TITLE
MouseEvent

### DIFF
--- a/extension/shared.js
+++ b/extension/shared.js
@@ -12,8 +12,8 @@ function simulateClick(element) {
 
     var click = new MouseEvent("click", {
         bubbles: true,
-		cancelable: false,
-		view: window,
+        cancelable: false,
+        view: window,
     });
     return element.dispatchEvent(click);
 }

--- a/extension/shared.js
+++ b/extension/shared.js
@@ -10,8 +10,11 @@ function simulateClick(element) {
         return false;
     } 
 
-    var click = document.createEvent('MouseEvents');
-    click.initMouseEvent('click', true, false,  document, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+    var click = new MouseEvent("click", {
+        bubbles: true,
+		cancelable: false,
+		view: window,
+    });
     return element.dispatchEvent(click);
 }
 


### PR DESCRIPTION
Proper pull request for MouseEvent change. This code (according to the internet) is more standard and compatible and not deprecated like initMouseEvent. Note that Mozilla lists initMouseEvent as deprecated but I have not looked into the status of deprecation in Chrome.