### PR TITLE
Click helper

### DIFF
--- a/extension/keysocket-amazon-cloud-player.js
+++ b/extension/keysocket-amazon-cloud-player.js
@@ -1,12 +1,9 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('[playeraction=next]');
-        simulateClick(nextButton);
+        simulateSelectorClick('[playeraction=next]');
     } else if (key === PLAY) {
-        var playPauseButton = document.querySelector('[playeraction=togglePlay]');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('[playeraction=togglePlay]');
     } else if (key === PREV) {
-        var backButton = document.querySelector('[playeraction=previous]');
-        simulateClick(backButton);
+        simulateSelectorClick('[playeraction=previous]');
     }
 }

--- a/extension/keysocket-digitallyimported.js
+++ b/extension/keysocket-digitallyimported.js
@@ -1,6 +1,5 @@
 function onKeyPress(key) {
     if (key === PLAY) {
-        var playPauseButton = document.querySelector('#webplayer-region .controls a:first-child');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('#webplayer-region .controls a:first-child');
     }
 }

--- a/extension/keysocket-dsaudio5.js
+++ b/extension/keysocket-dsaudio5.js
@@ -1,13 +1,10 @@
 function onKeyPress(key) {
     if (key === PREV) {
-        var prevButton = document.querySelector(".player-prev [type='button']");
-        simulateClick(prevButton);
+        simulateSelectorClick(".player-prev [type='button']");
     } else if (key === NEXT) {
-        var nextButton = document.querySelector(".player-next [type='button']");
-        simulateClick(nextButton);
+        simulateSelectorClick(".player-next [type='button']");
     } else if (key === PLAY) {
-        var playPauseButton = document.querySelector(".player-play [type='button']");
-        simulateClick(playPauseButton);
+        simulateSelectorClick(".player-play [type='button']");
     }
 }
 

--- a/extension/keysocket-gaana.js
+++ b/extension/keysocket-gaana.js
@@ -1,16 +1,12 @@
 function onKeyPress(key) {
-    if (key == NEXT) {
-        var nextbutton = document.querySelector('div.player_wrapper > a.next');
-        simulateClick(nextbutton);
-    } else if (key == PREV) {
-        var prevbutton = document.querySelector('div.player_wrapper > a.prev');
-        simulateClick(prevbutton);
-    } else if (key == PLAY) {
-        var playbutton = document.querySelector('div.player_wrapper > a.playPause.pause');
-        var pausebutton = document.querySelector('div.player_wrapper > a.playPause.play');
-        if (playbutton)
-            simulateClick(playbutton);
+    if (key === NEXT) {
+        simulateSelectorClick('div.player_wrapper > a.next');
+    } else if (key === PREV) {
+        simulateSelectorClick('div.player_wrapper > a.prev');
+    } else if (key === PLAY) {
+        if (document.querySelector('div.player_wrapper > a.playPause.play'))
+            simulateSelectorClick('div.player_wrapper > a.playPause.pause');
         else
-            simulateClick(pausebutton);
+            simulateSelectorClick('div.player_wrapper > a.playPause.play');
     }
 }

--- a/extension/keysocket-gmusic.js
+++ b/extension/keysocket-gmusic.js
@@ -1,13 +1,10 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('[data-id=forward]');
-        simulateClick(nextButton);
+        simulateSelectorClick('[data-id=forward]');
     } else if (key === PLAY) {
-        var playPauseButton = document.querySelector('[data-id=play-pause]');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('[data-id=play-pause]');
     } else if (key === PREV) {
-        var backButton = document.querySelector('[data-id=rewind]');
-        simulateClick(backButton);
+        simulateSelectorClick('[data-id=rewind]');
     }
 }
 

--- a/extension/keysocket-grooveshark.js
+++ b/extension/keysocket-grooveshark.js
@@ -1,12 +1,9 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.getElementById('play-next');
-        simulateClick(nextButton);
+        simulateSelectorClick('#play-next');
     } else if (key === PLAY) {
-        var playPauseButton = document.getElementById('play-pause');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('#play-pause');
     } else if (key === PREV) {
-        var backButton = document.getElementById('play-prev');
-        simulateClick(backButton);
+        simulateSelectorClick('#play-prev');
     }
 }

--- a/extension/keysocket-hypem.js
+++ b/extension/keysocket-hypem.js
@@ -1,9 +1,9 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        simulateClick(document.querySelector('#playerNext'));
+        simulateSelectorClick('#playerNext');
     } else if (key === PLAY) {
-        simulateClick(document.querySelector('#playerPlay'));
+        simulateSelectorClick('#playerPlay');
     } else if (key === PREV) {
-        simulateClick(document.querySelector('#playerPrev'));
+        simulateSelectorClick('#playerPrev');
     }
 }

--- a/extension/keysocket-jango.js
+++ b/extension/keysocket-jango.js
@@ -1,10 +1,7 @@
 function onKeyPress(key) {
-    var frame = document.querySelector('[name=content]');
     if (key === NEXT) {
-        var nextButton = frame.contentDocument.getElementById('btn-ff');
-        simulateClick(nextButton);
+        simulateSelectorClick('#btn-ff', '[name=content]');
     } else if (key === PLAY) {
-        var playPauseButton = frame.contentDocument.getElementById('btn-playpause');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('#btn-playpause', '[name=content]');
     }
 }

--- a/extension/keysocket-musicchoice.js
+++ b/extension/keysocket-musicchoice.js
@@ -2,6 +2,6 @@ console.log('keysocket: Loading Music Choice extension');
 
 function onKeyPress(key) {
     if (key === PLAY) {
-        simulateClick(document.querySelector('#audiomute'));
+        simulateSelectorClick('#audiomute');
     }
 }

--- a/extension/keysocket-nml.js
+++ b/extension/keysocket-nml.js
@@ -1,18 +1,13 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('#ctrl-next');
-        simulateClick(nextButton);
+        simulateSelectorClick('#ctrl-next');
     } else if (key === PLAY) {
-        var isPlaying = document.querySelector('#ctrl-play').style.display == 'none';
-        var playPauseButton = null;
-        if (isPlaying) {
-            playPauseButton = document.querySelector('#ctrl-pause');
+        if (document.querySelector('#ctrl-play').style.display == 'none') {
+            simulateSelectorClick('#ctrl-pause');
         } else {
-            playPauseButton = document.querySelector('#ctrl-play');
+            simulateSelectorClick('#ctrl-play');
         }
-        simulateClick(playPauseButton);
     } else if (key === PREV) {
-        var prevButton = document.querySelector('#ctrl-previous');
-        simulateClick(prevButton);
+        simulateSelectorClick('#ctrl-previous');
     }
 }

--- a/extension/keysocket-now-jbhifi.js
+++ b/extension/keysocket-now-jbhifi.js
@@ -1,16 +1,12 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('li.next');
-        simulateClick(nextButton);
+        simulateSelectorClick('li.next');
     } else if (key === PLAY) {
-        var playPauseButton = document.querySelector('li.play-pause');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('li.play-pause');
     } else if (key === STOP) {
-        var playStopButton = document.querySelector('li.playing');
-        if (playStopButton != null) simulateClick(playStopButton);
+        if (document.querySelector('li.playing') != null) simulateSelectorClick('li.playing');
     } else if (key === PREV) {
-        var backButton = document.querySelector('li.prev');
-        simulateClick(backButton);
+        simulateSelectorClick('li.prev');
     }
 }
 

--- a/extension/keysocket-ok.js
+++ b/extension/keysocket-ok.js
@@ -1,13 +1,9 @@
-var playTarget = '.mus_player-controls_i.__pause, .toolbar_music-play';
-var nextTarget = '.mus_player-controls_i.__forward';
-var prevTarget = '.mus_player-controls_i.__back';
-
 function onKeyPress(key) {
     if (key === PREV) {
-        simulateClick(document.querySelector(prevTarget));
+        simulateSelectorClick('.mus_player-controls_i.__back');
     } else if (key === NEXT) {
-        simulateClick(document.querySelector(nextTarget));
+        simulateSelectorClick('.mus_player-controls_i.__forward');
     } else if (key === PLAY) {
-        simulateClick(document.querySelector(playTarget));
+        simulateSelectorClick('.mus_player-controls_i.__pause, .toolbar_music-play');
     }
 }

--- a/extension/keysocket-pandora.js
+++ b/extension/keysocket-pandora.js
@@ -1,15 +1,11 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('div.skipButton > a');
-        simulateClick(nextButton);
+        simulateSelectorClick('div.skipButton > a');
     } else if (key === PLAY) {
-        var isPlaying = document.querySelector('div.playButton').style.display !== 'block';
-        var playPauseButton = null;
-        if (isPlaying) {
-            playPauseButton = document.querySelector('div.pauseButton > a');
+        if (document.querySelector('div.playButton').style.display !== 'block') {
+            simulateSelectorClick('div.pauseButton > a');
         } else {
-            playPauseButton = document.querySelector('div.playButton > a');
+            simulateSelectorClick('div.playButton > a');
         }
-        simulateClick(playPauseButton);
     }
 }

--- a/extension/keysocket-phishtracks.js
+++ b/extension/keysocket-phishtracks.js
@@ -1,13 +1,10 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('[data-control=next]');
-        simulateClick(nextButton);
+        simulateSelectorClick('[data-control=next]');
     } else if (key === PLAY) {
-        var playPauseButton = document.querySelector('[data-control=togglePause]');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('[data-control=togglePause]');
     } else if (key === PREV) {
-        var backButton = document.querySelector('[data-control=prev]');
-        simulateClick(backButton);
+        simulateSelectorClick('[data-control=prev]');
     }
 }
 

--- a/extension/keysocket-plex.js
+++ b/extension/keysocket-plex.js
@@ -1,26 +1,19 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('button.next-btn');
-        simulateClick(nextButton);
+        simulateSelectorClick('button.next-btn');
     } else if (key === PLAY) {
-        var playButton = document.querySelector('button.play-btn'),
-            pauseButton;
         try {
-            if (playButton.classList.contains('hidden')) {
-                pauseButton = document.querySelector('button.pause-btn');
-                simulateClick(pauseButton);
+            if (document.querySelector('button.play-btn').classList.contains('hidden')) {
+                simulateSelectorClick('button.pause-btn');
             } else {
-                simulateClick(playButton);
+                simulateSelectorClick('button.play-btn');
             }
         } catch (e) {
-            var playAllButton = document.querySelector('a.play-btn');
-            simulateClick(playAllButton);
+            simulateSelectorClick('a.play-btn');
         }
     } else if (key === PREV) {
-        var backButton = document.querySelector('button.previous-btn');
-        simulateClick(backButton);
+        simulateSelectorClick('button.previous-btn');
     } else if (key === STOP) {
-        var stopButton = document.querySelector('button.stop-btn');
-        simulateClick(stopButton);
+        simulateSelectorClick('button.stop-btn');
     }
 }

--- a/extension/keysocket-rdio.js
+++ b/extension/keysocket-rdio.js
@@ -1,12 +1,9 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('.left_controls .next');
-        simulateClick(nextButton);
+        simulateSelectorClick('.left_controls .next');
     } else if (key === PLAY) {
-        var playPauseButton = document.querySelector('.left_controls .play_pause');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('.left_controls .play_pause');
     } else if (key === PREV) {
-        var backButton = document.querySelector('.left_controls .prev');
-        simulateClick(backButton);
+        simulateSelectorClick('.left_controls .prev');
     }
 }

--- a/extension/keysocket-saavn.js
+++ b/extension/keysocket-saavn.js
@@ -1,19 +1,15 @@
 function onKeyPress(key) {
-    if (key == NEXT) {
-        var nextbutton = document.querySelector('button#fwd');
-        simulateClick(nextbutton);
-    } else if (key == PREV) {
-        var prevbutton = document.querySelector('button#rew');
-        simulateClick(prevbutton);
-    } else if (key == PLAY) {
-        var playbutton = document.querySelector('button#play');
-        var pausebutton = document.querySelector('button#pause');
+    if (key === NEXT) {
+        simulateSelectorClick('button#fwd');
+    } else if (key === PREV) {
+        simulateSelectorClick('button#rew');
+    } else if (key === PLAY) {
         var hidebutton = document.querySelector('button.controls.hide');
         if (hidebutton != null) {
             if (hidebutton.id == 'play')
-                simulateClick(pausebutton);
+                simulateSelectorClick('button#pause');
             else
-                simulateClick(playbutton);
+                simulateSelectorClick('button#play');
         }
     }
 

--- a/extension/keysocket-slacker.js
+++ b/extension/keysocket-slacker.js
@@ -1,12 +1,9 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.getElementById('playerSkipButton');
-        simulateClick(nextButton);
+        simulateSelectorClick('#playerSkipButton');
     } else if (key === PLAY) {
-        var playPauseButton = document.getElementById('playerPlayPauseButton');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('#playerPlayPauseButton');
     } else if (key === PREV) {
-        var backButton = document.getElementById('playerSkipBackButton');
-        simulateClick(backButton);
+        simulateSelectorClick('#playerSkipBackButton');
     }
 }

--- a/extension/keysocket-songza.js
+++ b/extension/keysocket-songza.js
@@ -1,9 +1,7 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('#player .miniplayer-control-skip');
-        simulateClick(nextButton);
+        simulateSelectorClick('#player .miniplayer-control-skip');
     } else if (key === PLAY) {
-        var playPauseButton = document.querySelector('#player .miniplayer-control-play-pause');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('#player .miniplayer-control-play-pause');
     }
 }

--- a/extension/keysocket-soundcloud.js
+++ b/extension/keysocket-soundcloud.js
@@ -1,9 +1,9 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        clickHelper('.skipControl__next');
+        simulateSelectorClick('.skipControl__next');
     } else if (key === PLAY) {
-        simulateClick('.playControl');
+        simulateSelectorClick('.playControl');
     } else if (key === PREV) {
-        simulateClick('.skipControl__previous');
+        simulateSelectorClick('.skipControl__previous');
     }
 }

--- a/extension/keysocket-soundcloud.js
+++ b/extension/keysocket-soundcloud.js
@@ -1,12 +1,9 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('.skipControl__next');
-        simulateClick(nextButton);
+        clickHelper('.skipControl__next');
     } else if (key === PLAY) {
-        var playPauseButton = document.querySelector('.playControl');
-        simulateClick(playPauseButton);
+        simulateClick('.playControl');
     } else if (key === PREV) {
-        var backButton = document.querySelector('.skipControl__previous');
-        simulateClick(backButton);
+        simulateClick('.skipControl__previous');
     }
 }

--- a/extension/keysocket-spotify.js
+++ b/extension/keysocket-spotify.js
@@ -1,9 +1,9 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        clickHelper('#next', '#app-player');
+        simulateSelectorClick('#next', '#app-player');
     } else if (key === PLAY) {
-        clickHelper('#play-pause', '#app-player');
+        simulateSelectorClick('#play-pause', '#app-player');
     } else if (key === PREV) {
-        clickHelper('#previous', '#app-player');
+        simulateSelectorClick('#previous', '#app-player');
     }
 }

--- a/extension/keysocket-spotify.js
+++ b/extension/keysocket-spotify.js
@@ -1,13 +1,9 @@
 function onKeyPress(key) {
-    var frame = document.getElementById('app-player');
     if (key === NEXT) {
-        var nextButton = frame.contentDocument.getElementById('next');
-        simulateClick(nextButton);
+        clickHelper('#next', '#app-player');
     } else if (key === PLAY) {
-        var playPauseButton = frame.contentDocument.getElementById('play-pause');
-        simulateClick(playPauseButton);
+        clickHelper('#play-pause', '#app-player');
     } else if (key === PREV) {
-        var backButton = frame.contentDocument.getElementById('previous');
-        simulateClick(backButton);
+        clickHelper('#previous', '#app-player');
     }
 }

--- a/extension/keysocket-t61.js
+++ b/extension/keysocket-t61.js
@@ -1,18 +1,13 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.getElementById('large_next_song_button');
-        simulateClick(nextButton);
+        simulateSelectorClick('#large_next_song_button');
     } else if (key === PLAY) {
-        var isPlaying = document.getElementById('pause_button').style.display !== 'none';
-        var playPauseButton = null;
-        if (isPlaying) {
-            playPauseButton = document.getElementById('pause_button');
+        if (document.querySelector('#pause_button').style.display !== 'none') {
+            simulateSelectorClick('#pause_button');
         } else {
-            playPauseButton = document.getElementById('play_button');
+            simulateSelectorClick('#play_button');
         }
-        simulateClick(playPauseButton);
     } else if (key === PREV) {
-        var backButton = document.getElementById('large_previous_song_button');
-        simulateClick(backButton);
+        simulateSelectorClick('#large_previous_song_button');
     }
 }

--- a/extension/keysocket-tidal.js
+++ b/extension/keysocket-tidal.js
@@ -1,21 +1,13 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('button.play-controls__next');
-        simulateClick(nextButton);
+        simulateSelectorClick('button.play-controls__next');
     } else if (key === PLAY) {
-        var playButton = document.querySelector('button.play-controls__play');
-        var pauseButton = document.querySelector('button.play-controls__pause');
-        if (isVisible(playButton)) {
-            simulateClick(playButton);
+        if (document.querySelector('button.play-controls__play').offsetParent != null) {
+            simulateSelectorClick('button.play-controls__play');
         } else {
-            simulateClick(pauseButton);
+            simulateSelectorClick('button.play-controls__pause');
         }
     } else if (key === PREV) {
-        var backButton = document.querySelector('button.play-controls__previous');
-        simulateClick(backButton);
+        simulateSelectorClick('button.play-controls__previous');
     }
-}
-
-function isVisible(el) {
-    return el.offsetParent != null;
 }

--- a/extension/keysocket-xboxmusic.js
+++ b/extension/keysocket-xboxmusic.js
@@ -1,13 +1,10 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.querySelector('.iconPlayerNext');
-        simulateClick(nextButton);
+        simulateSelectorClick('.iconPlayerNext');
     } else if (key === PLAY) {
-        var playPauseButton = document.querySelector('.iconPlayerPause') || document.querySelector('.iconPlayerPlay');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('.iconPlayerPause, .iconPlayerPlay');
     } else if (key === PREV) {
-        var backButton = document.querySelector('.iconPlayerPrevious');
-        simulateClick(backButton);
+        simulateSelectorClick('.iconPlayerPrevious');
     }
 }
 

--- a/extension/keysocket-xiami.js
+++ b/extension/keysocket-xiami.js
@@ -1,12 +1,9 @@
 function onKeyPress(key) {
     if (key === NEXT) {
-        var nextButton = document.getElementById('J_nextBtn');
-        simulateClick(nextButton);
+        simulateSelectorClick('#J_nextBtn');
     } else if (key === PLAY) {
-        var playPauseButton = document.getElementById('J_playBtn');
-        simulateClick(playPauseButton);
+        simulateSelectorClick('#J_playBtn');
     } else if (key === PREV) {
-        var backButton = document.getElementById('J_prevBtn');
-        simulateClick(backButton);
+        simulateSelectorClick('#J_prevBtn');
     }
 }

--- a/extension/keysocket-yandex-music.js
+++ b/extension/keysocket-yandex-music.js
@@ -1,14 +1,9 @@
-// support both old and new Yandex Music interfaces: '.old, .new'
-var playTarget = '.b-jambox__play, .player-controls__btn_play';
-var nextTarget = '.b-jambox__next, .player-controls__btn_next';
-var prevTarget = '.b-jambox__prev, .player-controls__btn_prev';
-
 function onKeyPress(key) {
     if (key === PREV) {
-        simulateClick(document.querySelector(prevTarget));
+        simulateSelectorClick('.b-jambox__play, .player-controls__btn_play');
     } else if (key === NEXT) {
-        simulateClick(document.querySelector(nextTarget));
+        simulateSelectorClick('.b-jambox__next, .player-controls__btn_next');
     } else if (key === PLAY) {
-        simulateClick(document.querySelector(playTarget));
+        simulateSelectorClick('.b-jambox__prev, .player-controls__btn_prev');
     }
 }

--- a/extension/shared.js
+++ b/extension/shared.js
@@ -33,7 +33,7 @@ function simulateClick(element) {
     return element.dispatchEvent(click);
 }
 
-function clickHelper(element, frame) {
+function simulateSelectorClick(element, frame) {
     if (!element) {
         console.log('keysocket: Cannot simulate click, element undefined');
         return false;

--- a/extension/shared.js
+++ b/extension/shared.js
@@ -18,6 +18,26 @@ function simulateClick(element) {
     return element.dispatchEvent(click);
 }
 
+function clickHelper(element, frame) {
+    if (!element) {
+        console.log('keysocket: Cannot simulate click, element undefined');
+        return false;
+    }
+
+    var click = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: false,
+        view: window,
+    });
+
+    if (frame !== 'undefined') {
+      clickOn = document.querySelector(frame).contentDocument;
+    } else {
+      clickOn = document;
+    }
+    return clickOn.querySelector(element).dispatchEvent(click);
+}
+
 chrome.runtime.onMessage.addListener(
     function(request) {
         console.log('Received keypress: ', request);


### PR DESCRIPTION
In a previous attempt to submit way too much, one of the comments had mentioned a click helper function that could aid in simplifying the code. This pull satisfies that idea.
The clickHelper function is able to fully replace the simulateClick function, but both are still included and will work side by side.
I have included SoundCloud as an example of the clickHelper where there is no frame involved in the player.
I have included Spotify as an example of the clickHelper where there is a frame housing the player.
Both players have been tested.