### PR TITLE
Added support for Chrome's built-in MP3 audio player

### DIFF
--- a/extension/keysocket-builtin-player.js
+++ b/extension/keysocket-builtin-player.js
@@ -1,0 +1,12 @@
+function onKeyPress(key) {
+    var videoElement = document.getElementsByTagName("video")[0];
+    
+    if (key === PLAY) {
+        if (videoElement.paused) {
+            videoElement.play();
+        }
+        else {
+            videoElement.pause();
+        }
+    }
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -205,6 +205,10 @@
     {
       "matches": ["*://zvooq.ru/*"],
       "js": ["shared.js", "keysocket-zvooq.js"]
+    },
+    {
+      "matches": ["*://*/*.mp3"],
+      "js": ["shared.js", "keysocket-builtin-player.js"]
     }
   ]
 }


### PR DESCRIPTION
This supports the built-in audio player that Chrome uses when navigating directly to an MP3 URL (if the user doesn't have any plugins that are already handling MP3s).

The built-in player is simply a video tag so this could also work for mp4s or other file types that Chrome plays natively, but I just set the matcher URL to *.mp3 for now.