### PR TITLE
Added a wildcard to MP3 URLs to handle query string parameters

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -207,7 +207,7 @@
       "js": ["shared.js", "keysocket-zvooq.js"]
     },
     {
-      "matches": ["*://*/*.mp3"],
+      "matches": ["*://*/*.mp3*"],
       "js": ["shared.js", "keysocket-builtin-player.js"]
     }
   ]


### PR DESCRIPTION
I've encountered a few sites whose podcasts URL links to MP3 files require query string parameters to be present. The wildcards allows them.