### PR TITLE
MP3 URLs with query strings are now handled

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -207,7 +207,7 @@
       "js": ["shared.js", "keysocket-zvooq.js"]
     },
     {
-      "matches": ["*://*/*.mp3"],
+      "matches": ["*://*/*.mp3*"],
       "js": ["shared.js", "keysocket-builtin-player.js"]
     }
   ]

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -207,7 +207,7 @@
       "js": ["shared.js", "keysocket-zvooq.js"]
     },
     {
-      "matches": ["*://*/*.mp3*"],
+      "matches": ["*://*/*.mp3", "*://*/*.mp3?*"],
       "js": ["shared.js", "keysocket-builtin-player.js"]
     }
   ]


### PR DESCRIPTION
Updated the match statement to also match against URLs ending in .mp3 that also include query string parameters. For example:

    http://host.com/foo/mp3?param=123