### PR TITLE
Add Noon Pacific (noonpacific.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
    * Livestream.com
    * Music Choice
    * Naxos Music Library
+   * Noon Pacific
    * Ok.ru
    * Overcast
    * Pandora

--- a/extension/keysocket-noon-pacific.js
+++ b/extension/keysocket-noon-pacific.js
@@ -1,0 +1,26 @@
+var playPauseButtonSelectors = [
+    '.control-buttons .fa-pause',
+    '.control-buttons .fa-play',
+    '[ng-click="PlayPauseClick()"]',
+    '[ng-click^="playPause"]',
+    '[ng-click^="player.play"]:not(.ng-hide)',
+    '[class*="pause"]'
+];
+
+function onKeyPress(key) {
+    if (key === PLAY) {
+        for (var i = 0; i < playPauseButtonSelectors.length; i++) {
+            var playPauseButtonCandidate = document.querySelector(playPauseButtonSelectors[i]);
+            if (playPauseButtonCandidate) {
+                simulateClick(playPauseButtonCandidate, {cancelable: true});
+                return;
+            }
+        }
+    } else if (key === NEXT) {
+        var nextButton = document.querySelector('[ng-click="audio.PlayNextSong()"], .fa-forward');
+        simulateClick(nextButton, {cancelable: true});
+    } else if (key === PREV) {
+        var prevButton = document.querySelector('[ng-click="audio.PlayPreviousSong()"], .fa-backward');
+        simulateClick(prevButton, {cancelable: true});
+    }
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -171,6 +171,10 @@
       "js": ["shared.js","keysocket-overcast.js"]
     },
     {
+      "matches": ["*://noonpacific.com/*"],
+      "js": ["shared.js","keysocket-noon-pacific.js"]
+    },
+    {
       "matches": ["*://plex.tv/web/*"],
       "js": ["shared.js","keysocket-plex.js"]
     },

--- a/extension/shared.js
+++ b/extension/shared.js
@@ -19,17 +19,21 @@ var NEXT = 'next';
 var STOP = 'stop';
 
 
-function simulateClick(element) {
+function simulateClick(element, options) {
     if (!element) {
         console.log('keysocket: Cannot simulate click, element undefined');
         return false;
     }
 
-    var click = new MouseEvent('click', {
+    var clickConfig = {
         bubbles: true,
         cancelable: false,
         view: window,
-    });
+    };
+    if (options && options.cancelable) {
+        clickConfig.cancelable = options.cancelable;
+    }
+    var click = new MouseEvent('click', clickConfig);
     return element.dispatchEvent(click);
 }
 


### PR DESCRIPTION
Note that on noonpacific.com the simulated click only worked correctly with cancelable = true. [1] cancelable = true was not the default, so I had to create a way to override the default by passing an `options` object. The existing usage of `simulateClick`, where only one parameter (the element) is passed, should still work as before.

[1] The control buttons on noonpacific.com are actually anchors (`a` tags with `href` set to an empty string) that reload the entire page by default, but the click handlers on noonpacific.com use preventDefault to prevent that, and create the wanted behavior. Only with cancelable = true can noonpacific.com correctly cancel the unwanted navigation, and perform the appropriate music control actions.
http://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-flow-cancelation
