### PR TITLE
support for synology standalone window

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -135,7 +135,7 @@
       "js": ["shared.js","keysocket-musicchoice.js"]
     },
     {
-      "matches": ["*://*/webman/*"],
+      "matches": ["*://*/webman/*", "*://*/audio/"],
       "js": ["shared.js","keysocket-dsaudio5.js"]
     },
     {


### PR DESCRIPTION
This should fix #85 

Unfortunately it only works if you run the standalone app with the default url path. If you want a more generalized support, you would need to introduce a options page and let the user select which code gets injected on which url.

This works for me an my setup. It should work for a lot of other people too.
