### PR TITLE
Add context menu for more extensive disable/enable options

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -19,6 +19,13 @@ var registerTab = function (tabId) {
         registeredTabs.push(tabId);
 
         chrome.pageAction.show(tabId);
+        chrome.pageAction.setIcon({
+            tabId: tabId,
+            path: {
+                '19': 'icons/icon19.png',
+                '38': 'icons/icon38.png'
+            }
+        });
         chrome.pageAction.setTitle({
             tabId: tabId,
             title: 'Click to disable media keys for this tab'
@@ -29,6 +36,18 @@ var unregisterTab = function(tabId) {
     var index = registeredTabs.indexOf(tabId);
     if (index > -1) {
         registeredTabs.splice(index, 1);
+
+        chrome.pageAction.setIcon({
+            tabId: tabId,
+            path: {
+                '19': 'icons/icon19-inactive.png',
+                '38': 'icons/icon38-inactive.png'
+            }
+        });
+        chrome.pageAction.setTitle({
+            tabId: tabId,
+            title: 'Click to enable media keys for this tab'
+        });
     }
 };
 
@@ -57,30 +76,34 @@ chrome.tabs.onRemoved.addListener(unregisterTab);
 chrome.pageAction.onClicked.addListener(function(tab) {
     var index = registeredTabs.indexOf(tab.id);
     if (index < 0) {
-        registeredTabs.push(tab.id);
-        chrome.pageAction.setIcon({
-            tabId: tab.id,
-            path: {
-                '19': 'icons/icon19.png',
-                '38': 'icons/icon38.png'
-            }
-        });
-        chrome.pageAction.setTitle({
-            tabId: tab.id,
-            title: 'Click to disable media keys for this tab'
-        });
+        registerTab(tab.id);
     } else {
-        registeredTabs.splice(index, 1);
-        chrome.pageAction.setIcon({
-            tabId: tab.id,
-            path: {
-                '19': 'icons/icon19-inactive.png',
-                '38': 'icons/icon38-inactive.png'
-            }
-        });
-        chrome.pageAction.setTitle({
-            tabId: tab.id,
-            title: 'Click to enable media keys for this tab'
-        });
+        unregisterTab(tab.id);
     }
 });
+
+chrome.contextMenus.create({id: "keySocketMediaKeys-group", title: "Key Socket Media Keys"});
+
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-disableThisTab", title: "Disable for this tab", onclick: function(a, tab){
+    unregisterTab(tab.id);
+}});
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-enableThisTab", title: "Enable for this tab", onclick: function(a, tab){
+    registerTab(tab.id);
+}});
+
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-separator1", type: "separator"});
+
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-disableAllTabs", title: "Disable for all tabs", onclick: function(a, tab){
+    chrome.tabs.getAllInWindow(null, function(tabs){
+        for (var i = 0; i < tabs.length; i++) {
+            unregisterTab(tabs[i].id);
+        }
+    });
+}});
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-enableAllTabs", title: "Enable for all tabs", onclick: function(a, tab){
+    chrome.tabs.getAllInWindow(null, function(tabs){
+        for (var i = 0; i < tabs.length; i++) {
+            registerTab(tabs[i].id);
+        }
+    });
+}});

--- a/extension/background.js
+++ b/extension/background.js
@@ -84,26 +84,52 @@ chrome.pageAction.onClicked.addListener(function(tab) {
 
 chrome.contextMenus.create({id: "keySocketMediaKeys-group", title: "Key Socket Media Keys"});
 
-chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-disableThisTab", title: "Disable for this tab", onclick: function(a, tab){
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-disableThisTab", title: "Disable this tab", onclick: function(a, tab){
     unregisterTab(tab.id);
 }});
-chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-enableThisTab", title: "Enable for this tab", onclick: function(a, tab){
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-enableThisTab", title: "Enable this tab", onclick: function(a, tab){
     registerTab(tab.id);
 }});
 
 chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-separator1", type: "separator"});
 
-chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-disableAllTabs", title: "Disable for all tabs", onclick: function(a, tab){
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-disableAllTabs", title: "Disable all tabs", onclick: function(a, tab){
     chrome.tabs.getAllInWindow(null, function(tabs){
         for (var i = 0; i < tabs.length; i++) {
             unregisterTab(tabs[i].id);
         }
     });
 }});
-chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-enableAllTabs", title: "Enable for all tabs", onclick: function(a, tab){
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-enableAllTabs", title: "Enable all tabs", onclick: function(a, tab){
     chrome.tabs.getAllInWindow(null, function(tabs){
         for (var i = 0; i < tabs.length; i++) {
             registerTab(tabs[i].id);
+        }
+    });
+}});
+
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-separator2", type: "separator"});
+
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-disableAllBut", title: "Disable all but this tab", onclick: function(a, tab){
+    chrome.tabs.getAllInWindow(null, function(tabs){
+        for (var i = 0; i < tabs.length; i++) {
+            if(tab.id !== tabs[i].id) {
+                unregisterTab(tabs[i].id);
+            }
+        }
+    });
+
+    registerTab(tab.id);
+}});
+
+chrome.contextMenus.create({parentId: "keySocketMediaKeys-group", id: "keySocketMediaKeys-enableAllBut", title: "Enable all but this tab", onclick: function(a, tab){
+    unregisterTab(tab.id);
+
+    chrome.tabs.getAllInWindow(null, function(tabs){
+        for (var i = 0; i < tabs.length; i++) {
+            if(tab.id !== tabs[i].id) {
+                registerTab(tabs[i].id);
+            }
         }
     });
 }});

--- a/extension/keysocket-streamsquid.js
+++ b/extension/keysocket-streamsquid.js
@@ -1,0 +1,17 @@
+function onKeyPress(key) {
+    if (key === NEXT) {
+        var nextButton = document.querySelector('#player-next');
+        simulateClick(nextButton);
+    } else if (key === PLAY) {
+        var playPauseButton = document.querySelector('#player-play');
+
+        if(document.querySelector('#player-pause').style.getPropertyValue("display") == "block"){
+            playPauseButton = document.querySelector('#player-pause');
+        }
+
+        simulateClick(playPauseButton);
+    } else if (key === PREV) {
+        var backButton = document.querySelector('#player-back');
+        simulateClick(backButton);
+    }
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -231,6 +231,10 @@
       "js": ["shared.js","keysocket-bandcamp.js"]
     },
     {
+      "matches": ["*://*.streamsquid.com/*"],
+      "js": ["shared.js","keysocket-streamsquid.js"]
+    },
+    {
       "matches": ["*://*/*.mp3", "*://*/*.mp3?*"],
       "js": ["shared.js", "keysocket-builtin-player.js"]
     }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,7 +8,7 @@
   },
   "description": "Control your favorite web-based music player with your keyboard's media keys",
   "homepage_url": "https://github.com/borismus/keysocket",
-  "permissions": ["tabs"],
+  "permissions": ["tabs", "contextMenus"],
   "manifest_version": 2,
   "commands": {
     "prev": {


### PR DESCRIPTION
EDIT: Closing this pull request, going 2 submit 2 different ones. One for Squidstream.com and another for the context menu.


Also added support for Streamsquid.com, didn't intend to have it in the same pull request but GitHub wouldn't let me exclude it.

I saw a couple issues asking for something kinda like this. (Not exactly, but for some of the ones I saw this would help with what they were complaining about. (Having to go through each tab and disable individually))

The `contextMenus` permission was added.

Image of the context menu: http://i.imgur.com/tH2C5dp.png http://i.imgur.com/jI8oRvv.png

Clicking on the icon still works like normal.

I also moved the icon changing lines (the ones that changed it to the disabled/enabled icon) to be inside the unregisterTab and registerTab functions. Was better that way so there wouldn't be multiple versions of those same lines inside the context menu code. (Because I had to make the icon update when the context menu buttons were clicked)