### PR TITLE
Add 22tracks, Birp, Bugs, Spreaker, and Streamsquid support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ when you're listening to music on various streaming websites.
 
 # Supported Sites
    * 8tracks
+   * 22tracks
    * Amazon Cloud Player
    * Bandcamp
+   * Birp
    * Bop
+   * Bugs Music
    * Chrome Built-In Player
-   * Comcast/xfinity
+   * Comcast/Xfinity
    * Deezer
    * Digitally Imported (di.fm)
    * Gaana.com
@@ -45,6 +48,8 @@ when you're listening to music on various streaming websites.
    * Songza
    * Soundcloud
    * Spotify
+   * Spreaker
+   * Streamsquid
    * Superplayer.fm
    * Synology Audio Station v.5
    * thesixtyone

--- a/extension/keysocket-birp.js
+++ b/extension/keysocket-birp.js
@@ -1,0 +1,12 @@
+function onKeyPress(key) {
+    if (key === NEXT) {
+        var nextButton = document.getElementById('fap-next');
+        simulateClick(nextButton);
+    } else if (key === PLAY) {
+        var playPauseButton = document.getElementById('fap-play-pause');
+        simulateClick(playPauseButton);
+    } else if (key === PREV) {
+        var backButton = document.getElementById('fap-previous');
+        simulateClick(backButton);
+    }
+}

--- a/extension/keysocket-bugs.js
+++ b/extension/keysocket-bugs.js
@@ -1,0 +1,12 @@
+function onKeyPress(key) {
+    if (key === NEXT) {
+        var nextButton = document.getElementsByTagName('button')[4];
+        simulateClick(nextButton);
+    } else if (key === PLAY) {
+        var playPauseButton = document.getElementsByTagName('button')[3];
+        simulateClick(playPauseButton);
+    } else if (key === PREV) {
+        var backButton = document.getElementsByTagName('button')[2];
+        simulateClick(backButton);
+    }
+}

--- a/extension/keysocket-spreaker.js
+++ b/extension/keysocket-spreaker.js
@@ -1,0 +1,12 @@
+function onKeyPress(key){
+    if(key === NEXT) {
+        var nextButton = document.getElementById('pl_next_button');
+        simulateClick(nextButton);
+    } else if(key === PLAY) {
+        var playPauseButton = document.getElementById('pl_play_button');
+        simulateClick(playPauseButton);
+    } else if(key === PREV) {
+        var backButton = document.getElementById('pl_prev_button');
+        simulateClick(backButton);
+    }
+}

--- a/extension/keysocket-streamsquid.js
+++ b/extension/keysocket-streamsquid.js
@@ -1,0 +1,17 @@
+function onKeyPress(key) {
+    if (key === NEXT) {
+        var nextButton = document.querySelector('#player-next');
+        simulateClick(nextButton);
+    } else if (key === PLAY) {
+        var playPauseButton = document.querySelector('#player-play');
+
+        if(document.querySelector('#player-pause').style.getPropertyValue("display") == "block"){
+            playPauseButton = document.querySelector('#player-pause');
+        }
+
+        simulateClick(playPauseButton);
+    } else if (key === PREV) {
+        var backButton = document.querySelector('#player-back');
+        simulateClick(backButton);
+    }
+}

--- a/extension/keysocket-twentytwotracks.js
+++ b/extension/keysocket-twentytwotracks.js
@@ -1,0 +1,12 @@
+function onKeyPress(key) {
+    if (key === NEXT) {
+        var nextButton = document.querySelector("[ng-click=\"Audio.next()\"]");
+        simulateClick(nextButton);
+    } else if (key === PLAY) {
+        var playPauseButton = document.querySelector("[ng-click=\"Audio.playpause()\"]");
+        simulateClick(playPauseButton);
+    } else if (key === PREV) {
+        var backButton = document.querySelector("[ng-click=\"Audio.previous()\"]");
+        simulateClick(backButton);
+    }
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -274,6 +274,26 @@
     {
       "matches": ["*://*.siriusxm.com/*"],
       "js": ["shared.js","keysocket-siriusxm.js"]
+    },
+    {
+      "matches": ["*://8tracks.com/*"],
+      "js": ["shared.js","keysocket-twentytwotracks.js"]
+    },
+    {
+      "matches": ["*://*.birp.fm/*"],
+      "js": ["shared.js", "keysocket-birp.js"]
+    },
+    {
+      "matches": ["http://music.bugs.co.kr/newPlayer*"],
+      "js": ["shared.js","keysocket-bugs.js"]
+    },
+    {
+      "matches": ["*://www.spreaker.com/*"],
+      "js": ["shared.js","keysocket-spreaker.js"]
+    },
+    {
+      "matches": ["*://*.streamsquid.com/*"],
+      "js": ["shared.js","keysocket-streamsquid.js"]
     }
   ]
 }


### PR DESCRIPTION
These additions were PRs that were rejected since the websites weren't popular enough (#93, #117, #119, #158, and #178, would have also done #157 if it wasn't force pushed), however I feel that this extension should provide as much compatibility as possible.  As much as I hate to say it, it's not popular enough for many sites to incorporate the event API method just yet.  I've tested these and confirmed that they function as expected.  :)