### PR TITLE
Support the current Plex URL

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -189,7 +189,7 @@
       "js": ["shared.js", "keysocket-picartotv.js"]
     },
     {
-      "matches": ["*://plex.tv/web/*"],
+      "matches": ["*://plex.tv/web/*", "*://app.plex.tv/web/*"],
       "js": ["shared.js", "keysocket-plex.js"]
     },
     {


### PR DESCRIPTION
Seems like Plex has changed their URL a bit, from something like:

https://plex.tv/web/app

to:

https://app.plex.tv/web/app