### PR TITLE
Plex changed URLs again

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -189,7 +189,7 @@
       "js": ["shared.js", "keysocket-picartotv.js"]
     },
     {
-      "matches": ["*://plex.tv/web/*", "*://app.plex.tv/web/*"],
+      "matches": ["*://plex.tv/web/*", "*://app.plex.tv/*"],
       "js": ["shared.js", "keysocket-plex.js"]
     },
     {


### PR DESCRIPTION
Plex changed from https://app.plex.tv/web/ to https://app.plex.tv/desktop, so I'm proposing just matching against anything on app.plex.tv.