### PR TITLE
Fix Jamstash Previous and Next Bindings

### DIFF
--- a/extension/keysocket-jamstash.js
+++ b/extension/keysocket-jamstash.js
@@ -9,8 +9,14 @@ keySocket.init(
             }
             keySocket.simulateClick(playPauseButton);
         },
-        "prev": "PreviousTrack",
-        "next": "NextTrack"
+        "prev": function () {
+            var prev = document.getElementById('PreviousTrack');
+            keySocket.simulateClick(prev);
+        },
+        "next": function () {
+            var next = document.getElementById('NextTrack');
+            keySocket.simulateClick(next);
+        }
         // stop is omitted
     }
 );


### PR DESCRIPTION
What/Why:

* A refactoring broke Jamstash Previous/Next track button bindings.

How:

* Use old method of looking an element's id and passing it to a call to
`simulateClick`.