### PR TITLE
Changed logic for handling multiple controllable tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.swp
 keysocket.zip
+*.crx
+*.pem

--- a/extension/background.html
+++ b/extension/background.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>keysocket</title>
+</head>
+<body>
+<script src="background.js"></script>
+</body>
+</html>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -45,7 +45,7 @@
     }
   },
   "background": {
-    "scripts": ["background.js"],
+	"page": "background.html",
     "persistent": true
   },
   "page_action": {

--- a/extension/plugin-api.js
+++ b/extension/plugin-api.js
@@ -122,13 +122,8 @@ keySocket.injectHandler = function (keysocketEventHandler)
         });
     };
 
-    injectFunction(handleKeysocketMessages);
-
+	injectCode('(' + handleKeysocketMessages + ')()');
     injectCode('window.keysocketOnKeyPressed = ' + keysocketEventHandler);
-
-    function injectFunction(injectionFunction) {
-        injectCode('(' + injectionFunction + ')()');
-    }
 
     function injectCode(injection) {
         var injectedScript = document.createElement('script');


### PR DESCRIPTION
I found this plugin cool but a little bit uncomfortable to use with multiple controllable tabs. So I changed the logic so that it controls tabs in next order:
if the music is already playing in tabs then control command goes only in these tabs
else if active tab is controllable then command goes in the active tab
else command goes in last controlled tab

I found this much more comfortable for me. But I understand that this is a major change so feel free to reject.