### PR TITLE
Support Deezer's new interface

### DIFF
--- a/extension/keysocket-deezer.js
+++ b/extension/keysocket-deezer.js
@@ -1,9 +1,9 @@
 keySocket.init(
     "deezer",
     {
-        "play-pause": ".control-play, .control-pause",
-        "prev": ".control-prev",
-        "next": ".control-next"
+        "play-pause": ".player-controls button[aria-label='Play'], .player-controls button[aria-label='Pause']",
+        "prev": ".player-controls button[aria-label='Back']",
+        "next": ".player-controls button[aria-label='Next']"
         // stop is omitted
     }
 );


### PR DESCRIPTION
These new queries support the new Deezer interface in beta (which is miles better), and is backward-compatible with the current interface at the same time.

The markup change was that they removed the `.control-*` class from all control buttons for some reason, so all of them have the same set of classes now. That's why I opted for using `aria-label` in queries.

The class `.player-controls` at the beginning of each query can be omitted (tested in both old and new interfaces, each query still returns the same single element), but I thought it's safer to keep it.

Everything was tested using latest Chrome (69) in both interfaces.