### PR TITLE
Add support for brain.fm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ when you're listening to music on various streaming websites.
    * Bandcamp
    * Birp
    * Bop
+   * Brain.fm
    * Bugs Music
    * Chrome Built-In Player
    * Comcast/Xfinity

--- a/extension/keysocket-brainfm.js
+++ b/extension/keysocket-brainfm.js
@@ -1,0 +1,9 @@
+keySocket.init(
+	"brainfm",
+	{
+		"play-pause": "[class*=\"PlayControl__wrapper\"]",
+		// prev is omitted
+		"next": "[class*=\"Skip__skip\"]"
+		// stop is omitted
+	}
+);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -85,6 +85,10 @@
       "js": ["plugin-api.js", "keysocket-birp.js"]
     },
     {
+      "matches": ["*://brain.fm/*"],
+      "js": ["plugin-api.js", "keysocket-brainfm.js"]
+    },
+    {
       "matches": ["http://music.bugs.co.kr/newPlayer*"],
       "js": ["plugin-api.js","keysocket-bugs.js"]
     },


### PR DESCRIPTION
I've taken a crack at resolving #278. Brain.fm offers 5 sessions with a free account, so even those who doesn't use the service should be able to test this addition.