### PR TITLE
Fix YouTube Music controls

### DIFF
--- a/extension/keysocket-youtube-music.js
+++ b/extension/keysocket-youtube-music.js
@@ -2,16 +2,16 @@ keySocket.init(
     "youtube.music",
     function (key) {
         if (key === keySocket.NEXT) {
-            var nextButton = document.querySelector('#left-controls > div > paper-icon-button:nth-child(3)');
+            var nextButton = document.querySelector('#left-controls > div > paper-icon-button.next-button');
             keySocket.simulateClick(nextButton);
         } else if (key === keySocket.PLAY) {
-            var playPauseButton = document.querySelector('#left-controls > div > paper-icon-button.play-pause-button.style-scope.ytmusic-player-bar');
+            var playPauseButton = document.querySelector('#left-controls > div > paper-icon-button.play-pause-button');
             playPauseButton.click();
         } else if (key === keySocket.PREV) {
-            var backButton = document.querySelector('#left-controls > div > paper-icon-button:nth-child(1)');
+            var backButton = document.querySelector('#left-controls > div > paper-icon-button.previous-button');
             keySocket.simulateClick(backButton);
         } else if (key === keySocket.STOP) {
-            var stopButton = document.querySelector('#left-controls > div > paper-icon-button.play-pause-button.style-scope.ytmusic-player-bar');
+            var stopButton = document.querySelector('#left-controls > div > paper-icon-button.play-pause-button');
             stopButton.click();
         }
     }


### PR DESCRIPTION
First of all, thanks for this extension. I use it every day 😄.

Since today (4/2/2019) the next button doesn't work anymore. This is because YouTube added a new element at position 3, causing `paper-icon-button:nth-child(3)` to fail.  
To fix this I've replaced the `nth-child`'s with the classname of the buttons.  
I've also removed `.style-scope.ytmusic-player-bar` since it doesn't add anything. If you want this reverted feel free to edit or ask it in the comments.

fixes #319 