### PR TITLE
Update domain: sowndhaus.com to sowndhaus.audio

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -237,7 +237,7 @@
       "js": ["plugin-api.js", "keysocket-soundcloud.js"]
     },
     {
-      "matches": ["https://sowndhaus.com/*"],
+      "matches": ["https://sowndhaus.audio/*"],
       "js": ["plugin-api.js", "keysocket-sowndhaus.js"]
     },
     {


### PR DESCRIPTION
sowndhaus.com has been replaced by sowndhaus.audio. All UI seems to be the same.