### PR TITLE
feat(extension): add Disney+ DOM selectors

### DIFF
--- a/extension/keysocket-disney-plus.js
+++ b/extension/keysocket-disney-plus.js
@@ -1,0 +1,6 @@
+keySocket.init("disney-plus", {
+    "play-pause": ".play-pause-icon",
+    prev: ".rwd-10sec-icon",
+    next: ".ff-10sec-icon",
+    // stop is omitted
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -109,6 +109,10 @@
       "js": ["plugin-api.js", "keysocket-digitallyimported.js"]
     },
     {
+      "matches": ["*://www.disneyplus.com/*/video/*"],
+      "js": ["plugin-api.js", "keysocket-disney-plus.js"]
+    },
+    {
       "matches": ["*://*.gaana.com/*"],
       "js": ["plugin-api.js", "keysocket-gaana.js"]
     },


### PR DESCRIPTION
I took a swing at adding support for [Disney+](https://www.disneyplus.com) based on the Netflix and Pocket Casts implementations.
I _think_ the DOM selectors are correct but I'm not 100% certain.
Should resolve #351.